### PR TITLE
Support MCE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY gunicorn_conf.py /app/
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY serve /
 
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
 RUN chmod 777 /serve
 
 ENTRYPOINT ["/serve"]

--- a/exec_cmd.py
+++ b/exec_cmd.py
@@ -2,7 +2,7 @@ import subprocess
 import time
 import flask
 import logging
-from flask import Flask,jsonify
+from flask import Flask, jsonify, request
 from os.path import exists
 import iperf3
 from multiprocessing import Process, Queue
@@ -15,7 +15,7 @@ import os
 app = Flask(__name__)
 Q = Queue()
 
-def get_primary_prompt_ip():
+def get_primary_prompt_ip_schema_v2():
     '''
     Implements a very simple method to retrieve an idle prompt server ready to take traffic.
     '''
@@ -52,20 +52,31 @@ def get_primary_prompt_ip():
     )
     return [{'key': item['EndpointName-Az-spine-partition']['S'], 'ipaddr': item['IpAddress']['S']} for item in ddb_response['Items']]
 
+def get_prompt_ips_schema_v1():
+    '''
+    Implements a very simple method to retrieve an idle MCE prompt server ready to take traffic.
+    '''
+    table_name = os.environ['ROUTING_TABLE_NAME']
+    ddb_entry_key = os.environ['ROUTING_ENTRY_KEY']
+
+    dynamodb = boto3.client('dynamodb', region_name='us-west-2')
+    ddb_response = dynamodb.get_item(TableName=table_name, Key={'EndpointName':{'S':ddb_entry_key}})
+    return [key for key in ddb_response['Item'] if key != 'EndpointName']
+
 def get_prompt_ports():
     '''
     Ports to connect to the prompt server.
     '''
     return [5001, 5002, 5003, 5004, 5005]
 
-def get_clients():
+def get_clients(server_ip):
     '''
     Generates a list of iperf3 clients. Each client use 5 streams.
     '''
     clients = []
     for port in get_prompt_ports():
         client = iperf3.Client()
-        client.server_hostname = get_primary_prompt_ip()
+        client.server_hostname = server_ip
         client.zerocopy = True
         client.verbose = True
         client.reverse = True
@@ -90,9 +101,32 @@ def serve():
     The standard API required for Sagemaker model container.
     This method is considered the backend of InvokeEndpoint() calls to a Sagemaker endpoint.
     '''
-    procs = []
 
-    for client in get_clients():
+    # Catching all exceptions to fall back to new DDB schema, including when no data provided.
+    try:
+        request_data = request.get_json(force=True)
+    except :
+        request_data = {}
+
+    SCHEMA_VER_KEY = "schema_ver"
+    schema_ver = request_data.get(SCHEMA_VER_KEY, "v2")
+    server_ips = []
+
+    if schema_ver == "v1":
+        server_ips += get_prompt_ips_schema_v1()
+    else:
+        server_ips += get_primary_prompt_ip_schema_v2()
+
+    response_dict = {}
+    for ip in server_ips:
+        clients = get_clients(ip)
+        response_dict.update(getBandwidth(clients))
+
+    return jsonify(response_dict)
+
+def getBandwidth(clients):
+    procs = []
+    for client in clients:
         proc = Process(target=start_bandwidth_test, args=[client])
         procs.append(proc)
         proc.start()
@@ -102,12 +136,12 @@ def serve():
 
     result = []
     total_speed = 0
-    for i in range(len(get_prompt_ports())):
+    for i in range(len(clients)):
         port_res = Q.get()
         total_speed += port_res["Speed"]
 
     total_Gbps = total_speed / 1000 # Gbps to Mbps conversion ratio is 1000, not 1024
-    return jsonify({"Total Bandwidth": "{} Gbps".format(total_Gbps)})
+    return {"Total Bandwidth connecting to prompt container IP {}".format(clients[0].server_hostname): "{} Gbps".format(total_Gbps)}
 
 @app.route('/ping', methods=['GET'])
 def ping():


### PR DESCRIPTION
1. Keeping the default API call POST /invocations behavior the same, either no data in the request or any data not equal to `"{\"schema_ver\":\"v1\"}"`
2. Support MCE in V1 schema where there are multiple prompt IPs to test. 

### Tested with data 
```
curl -X POST localhost:8080/invocations -d "{\"schema_ver\":\"v1\"}"

{"Total Bandwidth connecting to prompt container IP 240.0.219.100":"9.879208 Gbps",
"Total Bandwidth connecting to prompt container IP 240.0.235.199":"9.875191999999998 Gbps"}
```